### PR TITLE
updated rst link format

### DIFF
--- a/examples/document.rst
+++ b/examples/document.rst
@@ -5,42 +5,42 @@ A model for documents.
 
 **Allowed parameters**
 
-===============  ===========  ====================================
+===============  ===========  ==================================
 Allowed field    Data Type    Description
-===============  ===========  ====================================
-**id**           str          *The unique id of the document*
-**title**        str          *Document title*
-**ISBN**         int          *International Standard Book Number*
-===============  ===========  ====================================
+===============  ===========  ==================================
+**id**           str          The unique id of the document
+**title**        str          Document title
+**ISBN**         int          International Standard Book Number
+===============  ===========  ==================================
 
 **Allowed children**
 
-===============  ======================  ==============================
+===============  ======================  ============================
 Allowed child    Data Type               Description
-===============  ======================  ==============================
-**sections**     `Section <#section>`__  *The sections of the document*
-===============  ======================  ==============================
+===============  ======================  ============================
+**sections**     `Section <#section>`__  The sections of the document
+===============  ======================  ============================
 
 =======
 Section
 =======
-A model of a section of the `Document <#document>`__ . Will contain one `Paragraph <#paragraph>`__  or more.
+A model of a section of the `Document <#document>`__. Will contain one `Paragraph <#paragraph>`__ or more, i.e the `Paragraph(s) <#paragraph>`__ in the section, probably related to the **title** of the `Document <#document>`_.
 
 **Allowed parameters**
 
-===============  ===========  =======================
+===============  ===========  =====================
 Allowed field    Data Type    Description
-===============  ===========  =======================
-**id**           str          *The id of the section*
-===============  ===========  =======================
+===============  ===========  =====================
+**id**           str          The id of the section
+===============  ===========  =====================
 
 **Allowed children**
 
-===============  ==========================  ================
+===============  ==========================  ==============
 Allowed child    Data Type                   Description
-===============  ==========================  ================
-**paragraphs**   `Paragraph <#paragraph>`__  *The paragraphs*
-===============  ==========================  ================
+===============  ==========================  ==============
+**paragraphs**   `Paragraph <#paragraph>`__  The paragraphs
+===============  ==========================  ==============
 
 =========
 Paragraph
@@ -49,8 +49,8 @@ A model of a paragraph.
 
 **Allowed parameters**
 
-===============  ===========  ===================================================
+===============  ===========  ==============================================================
 Allowed field    Data Type    Description
-===============  ===========  ===================================================
-**contents**     str          *Paragraph contents, which make up the _Section_s.*
-===============  ===========  ===================================================
+===============  ===========  ==============================================================
+**contents**     str          Paragraph contents, which make up the `Sections <#section>`__.
+===============  ===========  ==============================================================

--- a/src/modelspec/base_types.py
+++ b/src/modelspec/base_types.py
@@ -594,7 +594,12 @@ class Base:
                 pre = text2[0:ind]
                 ref = text2[ind + len(code_ref) : ind2]
                 post = text2[ind2 + 1 :]
-                text2 = f"{pre}<b>{ref}</b>{post}"
+
+                if format == MARKDOWN_FORMAT:
+                    text2 = f"{pre}<b>{ref}</b>{post}"
+                elif format == RST_FORMAT:
+                    text2 = f"{pre}**{ref}**{post}"
+
             # print("    > Converted to: %s" % text2)
             text = text2
 
@@ -612,7 +617,23 @@ class Base:
                 if format == MARKDOWN_FORMAT:
                     text2 = f'{pre}<a href="#{ref.lower()}">{ref}</a>{post}'
                 elif format == RST_FORMAT:
-                    text2 = f"{pre}`{ref} <#{ref.lower()}>`__ {post}"
+                    rr = ref
+                    pp = post
+
+                    ######################################
+                    # Some hardcoded fixes for plurals...
+                    if pp.startswith("s "):
+                        rr += "s"
+                        pp = pp[1:]
+                    if pp.startswith("s."):
+                        rr += "s"
+                        pp = pp[1:]
+                    if pp.startswith("(s)"):
+                        rr += "(s)"
+                        pp = pp[3:]
+                    ######################################
+
+                    text2 = f"{pre}`{rr} <#{ref.lower()}>`__{pp}"
 
             # print("    > Converted to: %s" % text2)
             text = text2
@@ -694,7 +715,7 @@ class Base:
                     if referencable
                     else type_str,
                 )
-                d = "*%s*" % (insert_links(description, format=RST_FORMAT))
+                d = "%s" % (insert_links(description, format=RST_FORMAT))
                 table_info.append([n, t, d])
 
             if referencable:
@@ -755,7 +776,7 @@ class Base:
                     if referencable
                     else type_str,
                 )
-                d = "*%s*" % (insert_links(description, format=RST_FORMAT))
+                d = "%s" % (insert_links(description, format=RST_FORMAT))
                 table_info.append([n, t, d])
 
             # Get the contained type


### PR DESCRIPTION
- locally checked with restview
- confirmed with MDF repo's https://github.com/ModECI/MDF/blob/development/docs/sphinx/source/api/Specification.rst and works well(both HTML page and restview work well)
- solves issue #16 https://github.com/ModECI/MDF/issues/262 
- replaced single underscore with double underscore
- tried using [StackOverflow-link](https://stackoverflow.com/questions/15394347/adding-a-cross-reference-to-a-subheading-or-anchor-in-another-page) but :ref: wasn't interpreted