### PR TITLE
Generate and add contributors to documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,18 @@ jobs:
           cd examples/MDF
           python arrays.py -run   # test one example
 
+    - name: Build Documentation
+      run: |
+
+        pip install requests
+        pip install .[docs]
+        cd docs
+        python generate.py
+        python contributors.py
+        cd sphinx
+        make clean
+        make html
+
     - name: Final version info
       run: |
           pip list

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,6 @@ jobs:
     - name: Build Documentation
       run: |
 
-        pip install requests
         pip install .[docs]
         cd docs
         python generate.py

--- a/docs/contributors.py
+++ b/docs/contributors.py
@@ -1,0 +1,56 @@
+import requests
+import pandas as pd
+import json
+import textwrap
+from datetime import date
+
+
+url = "https://api.github.com/repos/modeci/modelspec/contributors"
+
+response = requests.get(url=url, auth=("<github_username>", "<github_token>"))
+
+json_data = response.json()
+
+df = pd.DataFrame(json_data)
+
+per_info = list(df["url"].unique())
+len_per_info = len(per_info)
+
+empty_list = []
+for i in range(len_per_info):
+    url = per_info[i]
+    print(url)
+    data = requests.get(url=url)
+    empty_list.append(data.json())
+
+df1 = pd.DataFrame(empty_list)
+df1["name"] = df1["name"].fillna("")
+name = df1["name"]
+login = df1["login"]
+url_html = df1["html_url"]
+url_id = df1["id"]
+
+login_html = list(zip(name, login, url_html))
+zip_dict = dict(zip(url_id, login_html))
+
+file = "sphinx/source/api/Contributors.md"
+with open(file, "w") as f:
+    print(
+        textwrap.dedent(
+            """\
+        (Modelspec:contributors)=
+
+        # Modelspec contributors
+
+        This page list names and Github profiles of contributors to Modelspec, listed in no particular order.
+        This page is generated periodically, most recently on {}.""".format(
+                date.today()
+            )
+        ),
+        file=f,
+    )
+
+    print("", file=f)
+
+    for key, val in zip_dict.items():
+        print("- {} ([@{}]({}))".format(val[0], val[1], val[2]), file=f)

--- a/docs/sphinx/source/api/Contributors.md
+++ b/docs/sphinx/source/api/Contributors.md
@@ -1,0 +1,11 @@
+(Modelspec:contributors)=
+
+# Modelspec contributors
+
+This page list names and Github profiles of contributors to Modelspec, listed in no particular order.
+This page is generated periodically, most recently on 2023-07-05.
+
+- Padraig Gleeson ([@pgleeson](https://github.com/pgleeson))
+- David Turner ([@davidt0x](https://github.com/davidt0x))
+- Parikshit Singh Rathore ([@parikshit14](https://github.com/parikshit14))
+- Katherine Mantel ([@kmantel](https://github.com/kmantel))

--- a/docs/sphinx/source/index.rst
+++ b/docs/sphinx/source/index.rst
@@ -20,6 +20,7 @@ It is still in development and it is being used by
    api/Introduction
    api/Quickstart
    api/Installation
+   api/Contributors
 
 
 .. toctree::

--- a/setup.cfg
+++ b/setup.cfg
@@ -67,6 +67,7 @@ test =
     typing_extensions; python_version<'3.8'
 
 docs =
+    requests
     Sphinx
     recommonmark>=0.5.0
     nbsphinx


### PR DESCRIPTION
Hi @pgleeson. I have added the contributors to modelspec documentation. 
The changes are:
1. There are two new files (contributors.py and Contributors.md). The contributors.py file generates "Contributors.md".
2. A modified "index.rst" to include contributors in the content of the documentation.

I look forward to your feedback. 
Thank you.