### PR TITLE
To 0.3.5; ensures numpy<2 in tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
     - name: Install package
       run: |
         python -m pip install --upgrade pip
+        pip install 'numpy<2.0.0' # due to lingering issues with other modules & numpy...
         pip install .[dev]
 
     - name: Lint with flake8

--- a/docs/sphinx/source/api/Contributors.md
+++ b/docs/sphinx/source/api/Contributors.md
@@ -3,7 +3,7 @@
 # Modelspec contributors
 
 This page list names and Github profiles of contributors to Modelspec, listed in no particular order.
-This page is generated periodically, most recently on 2024-05-01.
+This page is generated periodically, most recently on 2024-06-18.
 
 - Padraig Gleeson ([@pgleeson](https://github.com/pgleeson))
 - Manifest Chakalov  ([@mqnifestkelvin](https://github.com/mqnifestkelvin))

--- a/docs/sphinx/source/api/Contributors.md
+++ b/docs/sphinx/source/api/Contributors.md
@@ -3,7 +3,7 @@
 # Modelspec contributors
 
 This page list names and Github profiles of contributors to Modelspec, listed in no particular order.
-This page is generated periodically, most recently on 2024-04-25.
+This page is generated periodically, most recently on 2024-05-01.
 
 - Padraig Gleeson ([@pgleeson](https://github.com/pgleeson))
 - Manifest Chakalov  ([@mqnifestkelvin](https://github.com/mqnifestkelvin))

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,6 @@ classifiers =
     License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)
     Natural Language :: English
     Operating System :: OS Independent
-    Programming Language :: Python :: 3.7
     Topic :: Scientific/Engineering
     Intended Audience :: Science/Research
     Programming Language :: Python
@@ -26,6 +25,7 @@ classifiers =
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Topic :: Scientific/Engineering
     Topic :: Software Development
     Typing :: Typed
@@ -87,6 +87,7 @@ dev =
     NeuroMLlite>=0.5.3
     python-libsbml
     modelspec[test]
+    pre-commit
 
 all =
     modelspec[test]

--- a/src/modelspec/__init__.py
+++ b/src/modelspec/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.3.4"
+__version__ = "0.3.5"
 
 from .base_types import Base, define, has, field, fields, optional, instance_of, in_
 

--- a/test_all.sh
+++ b/test_all.sh
@@ -3,7 +3,7 @@ set -ex
 
 ## Install modelspec incl. dev dependencies
 
-pip install .[dev]
+pip install .[all]
 
 
 ## Test main example


### PR DESCRIPTION
Quick release to main, otherwise tests would be broken...